### PR TITLE
Add library scan throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,22 @@ When started for the first time HTTPMS will create one for you. Here is an examp
     "libraries": [
         "/path/to/my/files",
         "/some/more/files/can/be/found/here"
-    ]
+    ],
+    
+    // Optional configuration on how to scan libraries. Note that this configuration
+    // is applied to each library separately.
+    "library_scan": {
+        // Will wait this mutch time before actually starting to scan a library.
+        // This might be useful when scanning is resource hungry operation and you
+        // want to postpone it on startup.
+        "initial_wait_duration": "1s",
+        
+        // With this option a "operation" is defined by this number of scanned files.
+        "files_per_operation": 1500,
+
+        // After each "operation", sleep this amount of time.
+        "sleep_after_operation": "15ms"
+    }
 }
 ```
 

--- a/config.example.json
+++ b/config.example.json
@@ -18,5 +18,11 @@
     "libraries": [
         "/path/to/my/files",
         "/some/more/files/can/be/found/here"
-    ]
+    ],
+
+    "library_scan": {
+        "files_per_operation": 1500,
+        "sleep_after_operation": "15ms",
+        "initial_wait_duration": "1s"
+    }
 }

--- a/src/library/local_library.go
+++ b/src/library/local_library.go
@@ -3,6 +3,7 @@ package library
 import (
 	"database/sql"
 	"errors"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -15,6 +16,7 @@ import (
 	taglib "github.com/landr0id/go-taglib"
 	_ "github.com/mattn/go-sqlite3"
 
+	"github.com/ironsmile/httpms/src/config"
 	"github.com/ironsmile/httpms/src/helpers"
 )
 
@@ -23,8 +25,29 @@ import (
 // one of them will be saved in the library.
 const UNKNOWN_LABEL = "Unknown"
 
+var (
+	// LibraryFastScan is a flag, populated by the -fast-library-scan argument.
+	//
+	// When `false` (the default), scanning the local library will honour the
+	// configuration for occasional sleeping while scanning the file system.
+	//
+	// When `true`, scanning will be as fast as possible. This may generate high
+	// IO load for the duration of the scan.
+	LibraryFastScan bool
+)
+
+func init() {
+	flag.BoolVar(&LibraryFastScan, "fast-library-scan", false, "Do not honour"+
+		" the configuration set in 'library_scan'. With this flag,"+
+		" scanning will be done as fast as possible. This may be useful when"+
+		" running the daemon for the fists time with big libraries.")
+}
+
 // Implements the Library interface. Will represent files found on the local storage
 type LocalLibrary struct {
+	// The configuration for how to scan the libraries.
+	ScanConfig config.ScanSection
+
 	database string         // The location of the library's database
 	paths    []string       // FS locations which contain the library's media files
 	db       *sql.DB        // Database handler

--- a/src/main.go
+++ b/src/main.go
@@ -83,6 +83,8 @@ func getLibrary(userPath string, cfg config.Config) (library.Library, error) {
 		return nil, err
 	}
 
+	lib.ScanConfig = cfg.LibraryScan
+
 	err = lib.Initialize()
 
 	if err != nil {


### PR DESCRIPTION
Throttling is implemented and can be switched on by the configuration
directive "library_scan". This directive may be later used for
additional scanning configurations.

The command line flag `-fast-library-scan` can be used for bypassing
throttling entirely.