### PR TITLE
Start using temp files for library tests

### DIFF
--- a/src/library/local_library.go
+++ b/src/library/local_library.go
@@ -550,9 +550,8 @@ func (lib *LocalLibrary) lastInsertID() (int64, error) {
 // sqlite database file and creates one if it is absent. If a file is found
 // it does nothing.
 func (lib *LocalLibrary) Initialize() error {
-	_, err := os.Stat(lib.database)
 
-	if err == nil {
+	if st, err := os.Stat(lib.database); err == nil && st.Size() > 0 {
 		return nil
 	}
 

--- a/src/library/local_library_watch.go
+++ b/src/library/local_library_watch.go
@@ -81,7 +81,6 @@ func (lib *LocalLibrary) watchEventRoutine() {
 //  * modfied files should be updated in the database
 //  * renamed ...
 func (lib *LocalLibrary) handleWatchEvent(event *fsnotify.FileEvent) {
-	// log.Println("Watch event:", event)
 
 	if event.IsAttrib() {
 		// The event was just an attribute change


### PR DESCRIPTION
Using the same file name between different tests meant that it was
really likely that a previously failed test would leave behind a
database file and cause failure for all further runs.