### PR TITLE
Support albums with multiple artists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,6 @@ dist/*
 # The built binary
 httpms
 
+# OSX bullshits
+**/.DS_Store
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
-  - 1.7.1
+  - 1.7
+  - tip
 env:
   secure: "cgpnkmmHixR8jAwzO8MizqVUGK7GgWu27syhnnGtI2714JhH4ubuNguNn1St/m8tAmZFOeQmh4qmxRNLi6fNnHb1mOsavqrJr0kyZYADf5zz6fn03yEqzYIaNL0j6iuBin0XMJbfsxyR5tCGllCPm97CpXIF16GeJSbsY8B0Jts="
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.7
+  - 1.7.4
   - tip
 env:
   secure: "cgpnkmmHixR8jAwzO8MizqVUGK7GgWu27syhnnGtI2714JhH4ubuNguNn1St/m8tAmZFOeQmh4qmxRNLi6fNnHb1mOsavqrJr0kyZYADf5zz6fn03yEqzYIaNL0j6iuBin0XMJbfsxyR5tCGllCPm97CpXIF16GeJSbsY8B0Jts="

--- a/httpms_daemon/main.go
+++ b/httpms_daemon/main.go
@@ -54,6 +54,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	// #nosec
 	if out, err := exec.Command(path, "-p", pidFile).Output(); err != nil {
 		logger.Println(err)
 		os.Exit(1)

--- a/sqls/library_schema.sql
+++ b/sqls/library_schema.sql
@@ -1,7 +1,7 @@
 create table `albums` (
     `id` integer not null primary key, 
     `name` text,
-    `artist_id` integer not null
+    `fs_path` text
 );
 
 create table `artists` (

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -54,11 +54,11 @@ func getDefaultCfg() *Config {
 // checkMerge is a helper function for TestMergingConfigs
 func checkMerge(t *testing.T, cfg *Config) {
 
-	if cfg.SSL != true {
+	if !cfg.SSL {
 		t.Errorf("SSL was false but it was expected to be true")
 	}
 
-	if cfg.Auth != false {
+	if cfg.Auth {
 		t.Errorf("Auth was true but it was expected to be false")
 	}
 
@@ -74,7 +74,7 @@ func checkMerge(t *testing.T, cfg *Config) {
 		t.Errorf("Listen was %s", cfg.Listen)
 	}
 
-	if cfg.Gzip != true {
+	if !cfg.Gzip {
 		t.Errorf("Gzip was %t", cfg.Gzip)
 	}
 
@@ -122,7 +122,7 @@ func TestMergingConfigs(t *testing.T) {
 
 	cfg.merge(merged)
 
-	if cfg.SSL != true {
+	if !cfg.SSL {
 		t.Errorf("Zero value from the merged has been copied over")
 	}
 

--- a/src/library/library.go
+++ b/src/library/library.go
@@ -39,7 +39,7 @@ type Library interface {
 	AddLibraryPath(string)
 
 	// Search the library using a search string. It will match against Artist, Album
-	// and Title. Will OR the results. So it is "return anything which Artist maches or
+	// and Title. Will OR the results. So it is "return anything which Artist matches or
 	// Album matches or Title matches"
 	Search(string) []SearchResult
 

--- a/src/library/library.go
+++ b/src/library/library.go
@@ -49,12 +49,9 @@ type Library interface {
 	// Returns search result will all the files of this album
 	GetAlbumFiles(int64) []SearchResult
 
-	// Starts a background library scan. Will scan all paths if
-	// they are not scanned already. Will return immediately.
+	// Starts a full library scan. Will scan all paths if
+	// they are not scanned already.
 	Scan()
-
-	// Will sync with the Scan's end
-	WaitScan()
 
 	// Adds this media (file) to the library
 	AddMedia(string) error

--- a/src/library/library_test.go
+++ b/src/library/library_test.go
@@ -584,6 +584,10 @@ func checkAddedSong(lib *LocalLibrary, t *testing.T) {
 }
 
 func TestAddingNewFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	lib := getScannedLibrary(t)
 	defer lib.Truncate()
 	projRoot, _ := helpers.ProjectRoot()
@@ -599,10 +603,16 @@ func TestAddingNewFile(t *testing.T) {
 	defer os.Remove(newFile)
 	lib.WaitScan()
 
+	time.Sleep(1 * time.Second)
+
 	checkAddedSong(lib, t)
 }
 
 func TestMovingFileIntoLibrary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	lib := getScannedLibrary(t)
 	defer lib.Truncate()
 	projRoot, _ := helpers.ProjectRoot()
@@ -628,6 +638,10 @@ func TestMovingFileIntoLibrary(t *testing.T) {
 }
 
 func TestAddingNonRelatedFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	lib := getScannedLibrary(t)
 	defer lib.Truncate()
 	projRoot, _ := helpers.ProjectRoot()
@@ -660,6 +674,10 @@ func TestAddingNonRelatedFile(t *testing.T) {
 }
 
 func TestRemovingFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	projRoot, _ := helpers.ProjectRoot()
 	testFiles := filepath.Join(projRoot, "test_files")
 
@@ -692,6 +710,10 @@ func TestRemovingFile(t *testing.T) {
 }
 
 func TestAddingAndRemovingDirectory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	projRoot, _ := helpers.ProjectRoot()
 	testFiles := filepath.Join(projRoot, "test_files")
 
@@ -842,6 +864,10 @@ func checkSong(lib *LocalLibrary, song MediaFile, t *testing.T) {
 }
 
 func TestAddingManyFilesSimultaniously(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	lib := getPathedLibrary(t)
 	defer lib.Truncate()
 

--- a/src/library/library_test.go
+++ b/src/library/library_test.go
@@ -601,9 +601,7 @@ func TestAddingNewFile(t *testing.T) {
 	}
 
 	defer os.Remove(newFile)
-	lib.WaitScan()
-
-	time.Sleep(1 * time.Second)
+	lib.stop()
 
 	checkAddedSong(lib, t)
 }

--- a/src/library/library_test.go
+++ b/src/library/library_test.go
@@ -597,7 +597,7 @@ func TestAddingNewFile(t *testing.T) {
 	newFile := filepath.Join(testFiles, "library", "folder_one", "test_file_added.mp3")
 
 	if err := helpers.Copy(testMp3, newFile); err != nil {
-		t.Fatalf("Copying file to library faild: %s", err)
+		t.Fatalf("Copying file to library failed: %s", err)
 	}
 
 	defer os.Remove(newFile)

--- a/src/library/library_test.go
+++ b/src/library/library_test.go
@@ -121,7 +121,7 @@ func testErrorAfter(seconds time.Duration, message string) chan int {
 
 	go func() {
 		select {
-		case _ = <-ch:
+		case <-ch:
 			close(ch)
 			return
 		case <-time.After(seconds * time.Second):

--- a/src/library/library_test.go
+++ b/src/library/library_test.go
@@ -176,10 +176,14 @@ func TestInitialize(t *testing.T) {
 	}
 	defer db.Close()
 
-	var tables = []string{"albums", "tracks", "artists"}
+	var queries = []string{
+		"SELECT count(id) as cnt FROM albums",
+		"SELECT count(id) as cnt FROM tracks",
+		"SELECT count(id) as cnt FROM artists",
+	}
 
-	for _, table := range tables {
-		row, err := db.Query(fmt.Sprintf("SELECT count(id) as cnt FROM %s", table))
+	for _, query := range queries {
+		row, err := db.Query(query)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -732,7 +736,7 @@ func TestAddingAndRemovingDirectory(t *testing.T) {
 	lib := getScannedLibrary(t)
 	defer lib.Truncate()
 
-	if err := os.Mkdir(testDir, 0755); err != nil {
+	if err := os.Mkdir(testDir, 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -780,7 +784,7 @@ func TestMovingDirectory(t *testing.T) {
 	_ = os.RemoveAll(movedDir)
 	_ = os.RemoveAll(secondPlace)
 
-	if err := os.Mkdir(testDir, 0755); err != nil {
+	if err := os.Mkdir(testDir, 0700); err != nil {
 		t.Fatal(err)
 	}
 

--- a/src/library/library_test.go
+++ b/src/library/library_test.go
@@ -43,6 +43,16 @@ func init() {
 	}
 }
 
+func getTestLibraryPath() (string, error) {
+	projRoot, err := helpers.ProjectRoot()
+
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(projRoot, "test_files", "library"), nil
+}
+
 // It is the caller's resposibility to remove the library SQLite database file
 func getLibrary(t *testing.T) *LocalLibrary {
 
@@ -64,13 +74,7 @@ func getLibrary(t *testing.T) *LocalLibrary {
 		t.Fatalf("Initializing library: %s", err)
 	}
 
-	projRoot, err := helpers.ProjectRoot()
-
-	if err != nil {
-		t.Fatalf("Was not able to find test_files directory: %s", err)
-	}
-
-	testLibraryPath := filepath.Join(projRoot, "test_files", "library")
+	testLibraryPath, err := getTestLibraryPath()
 
 	_ = lib.AddMedia(filepath.Join(testLibraryPath, "test_file_two.mp3"))
 	_ = lib.AddMedia(filepath.Join(testLibraryPath, "folder_one", "third_file.mp3"))
@@ -340,6 +344,32 @@ func TestAddigNewFiles(t *testing.T) {
 
 	if track.Title != "Tittled Track" {
 		t.Errorf("Found track had the wrong title: %s", track.Title)
+	}
+}
+
+func TestAlbumFSPath(t *testing.T) {
+	library := getLibrary(t)
+	defer library.Truncate()
+
+	testLibraryPath, err := getTestLibraryPath()
+
+	if err != nil {
+		t.Fatalf("Cannot get test library path: %s", testLibraryPath)
+	}
+
+	albumPaths, err := library.GetAlbumFSPathByName("Album Of Tests")
+
+	if err != nil {
+		t.Fatalf("Was not able to find Album Of Tests: %s", err)
+	}
+
+	if len(albumPaths) != 1 {
+		t.Fatalf("Expected one path for an album but found %d", len(albumPaths))
+	}
+
+	if testLibraryPath != albumPaths[0] {
+		t.Errorf("Album path mismatch. Expected `%s` but got `%s`", testLibraryPath,
+			albumPaths[0])
 	}
 }
 

--- a/src/library/library_test.go
+++ b/src/library/library_test.go
@@ -766,6 +766,8 @@ func TestAddingAndRemovingDirectory(t *testing.T) {
 }
 
 func TestMovingDirectory(t *testing.T) {
+	t.Skip("Fails bevause of a race condition")
+
 	projRoot, _ := helpers.ProjectRoot()
 	testFiles := filepath.Join(projRoot, "test_files")
 

--- a/src/library/library_test.go
+++ b/src/library/library_test.go
@@ -259,7 +259,7 @@ func TestSearch(t *testing.T) {
 
 }
 
-func TestAddigNewFiles(t *testing.T) {
+func TestAddingNewFiles(t *testing.T) {
 
 	library := getLibrary(t)
 	defer library.Truncate()

--- a/src/library/library_test.go
+++ b/src/library/library_test.go
@@ -55,14 +55,7 @@ func getTestLibraryPath() (string, error) {
 
 // It is the caller's resposibility to remove the library SQLite database file
 func getLibrary(t *testing.T) *LocalLibrary {
-
-	fh, err := ioutil.TempFile("", "httpms_library_test_")
-
-	if err != nil {
-		t.Fatalf("Error creating temporary library: %s", err)
-	}
-
-	lib, err := NewLocalLibrary(fh.Name())
+	lib, err := NewLocalLibrary(context.TODO(), SQLiteMemoryFile)
 
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -92,13 +85,7 @@ func getPathedLibrary(t *testing.T) *LocalLibrary {
 
 	testLibraryPath := filepath.Join(projRoot, "test_files", "library")
 
-	fh, err := ioutil.TempFile("", "httpms_library_test_")
-
-	if err != nil {
-		t.Fatalf("Error creating temporary library: %s", err)
-	}
-
-	lib, err := NewLocalLibrary(fh.Name())
+	lib, err := NewLocalLibrary(context.TODO(), SQLiteMemoryFile)
 
 	if err != nil {
 		t.Fatal(err)
@@ -276,14 +263,8 @@ func TestAddigNewFiles(t *testing.T) {
 	library := getLibrary(t)
 	defer library.Truncate()
 
-	db, err := sql.Open("sqlite3", library.database)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-
 	tracksCount := func() int {
-		rows, err := db.Query("SELECT count(id) as cnt FROM tracks")
+		rows, err := library.db.Query("SELECT count(id) as cnt FROM tracks")
 		if err != nil {
 			t.Fatal(err)
 			return 0

--- a/src/library/library_test.go
+++ b/src/library/library_test.go
@@ -1,6 +1,7 @@
 package library
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
@@ -140,7 +141,7 @@ func TestInitialize(t *testing.T) {
 		t.Fatalf("Error creating temporary library: %s", err)
 	}
 
-	lib, err := NewLocalLibrary(libDB.Name())
+	lib, err := NewLocalLibrary(context.Background(), libDB.Name())
 
 	if err != nil {
 		t.Fatal(err)
@@ -193,7 +194,7 @@ func TestTruncate(t *testing.T) {
 		t.Fatalf("Error creating temporary library: %s", err)
 	}
 
-	lib, err := NewLocalLibrary(libDB.Name())
+	lib, err := NewLocalLibrary(context.TODO(), libDB.Name())
 
 	if err != nil {
 		t.Fatal(err)
@@ -466,7 +467,7 @@ func TestScaning(t *testing.T) {
 	lib.Scan()
 
 	ch := testErrorAfter(10, "Scanning library took too long")
-	lib.WaitScan()
+	lib.stop()
 	ch <- 42
 
 	for _, track := range []string{"Another One", "Payback", "Tittled Track"} {
@@ -476,7 +477,6 @@ func TestScaning(t *testing.T) {
 			t.Errorf("%s was not found after the scan", track)
 		}
 	}
-
 }
 
 func TestSQLInjections(t *testing.T) {
@@ -893,7 +893,7 @@ func TestAddingManyFilesSimultaniously(t *testing.T) {
 		mediaFiles = append(mediaFiles, m)
 	}
 
-	lib.waitForDBWriterIdleSignal()
+	lib.WaitScan()
 
 	for _, song := range mediaFiles {
 		checkSong(lib, song, t)
@@ -943,7 +943,7 @@ func TestAlbumsWithDifferentArtists(t *testing.T) {
 		}
 	}
 
-	lib.waitForDBWriterIdleSignal()
+	lib.WaitScan()
 
 	found := lib.Search("Return Of The Bugs")
 
@@ -1019,7 +1019,7 @@ func TestDifferentAlbumsWithTheSameName(t *testing.T) {
 		}
 	}
 
-	lib.waitForDBWriterIdleSignal()
+	lib.WaitScan()
 
 	found := lib.Search("Return Of The Bugs")
 

--- a/src/library/library_watch_test.go
+++ b/src/library/library_watch_test.go
@@ -1,0 +1,270 @@
+package library
+
+import (
+	_ "net/http/pprof"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ironsmile/httpms/src/helpers"
+)
+
+func TestMovingFileIntoLibrary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	lib := getScannedLibrary(t)
+	defer lib.Truncate()
+	projRoot, _ := helpers.ProjectRoot()
+	testFiles := filepath.Join(projRoot, "test_files")
+
+	testMp3 := filepath.Join(testFiles, "more_mp3s", "test_file_added.mp3")
+	toBeMoved := filepath.Join(testFiles, "more_mp3s", "test_file_moved.mp3")
+	newFile := filepath.Join(testFiles, "library", "test_file_added.mp3")
+
+	if err := helpers.Copy(testMp3, toBeMoved); err != nil {
+		t.Fatalf("Copying file to library faild: %s", err)
+	}
+
+	if err := os.Rename(toBeMoved, newFile); err != nil {
+		os.Remove(toBeMoved)
+		t.Fatalf("Was not able to move new file into library: %s", err)
+	}
+
+	defer os.Remove(newFile)
+
+	time.Sleep(100 * time.Millisecond)
+
+	lib.stop()
+
+	checkAddedSong(lib, t)
+}
+
+func TestRemovingFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	projRoot, _ := helpers.ProjectRoot()
+	testFiles := filepath.Join(projRoot, "test_files")
+
+	testMp3 := filepath.Join(testFiles, "more_mp3s", "test_file_added.mp3")
+	newFile := filepath.Join(testFiles, "library", "test_file_added.mp3")
+
+	if err := helpers.Copy(testMp3, newFile); err != nil {
+		t.Fatalf("Copying file to library faild: %s", err)
+	}
+
+	lib := getScannedLibrary(t)
+	defer lib.Truncate()
+
+	results := lib.Search("")
+
+	if len(results) != 4 {
+		t.Errorf("Expected 4 files in the result set but found %d", len(results))
+	}
+
+	if err := os.Remove(newFile); err != nil {
+		t.Error(err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	results = lib.Search("")
+	if len(results) != 3 {
+		t.Errorf("Expected 3 files in the result set but found %d", len(results))
+	}
+}
+
+func TestAddingAndRemovingDirectory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	projRoot, _ := helpers.ProjectRoot()
+	testFiles := filepath.Join(projRoot, "test_files")
+
+	testDir := filepath.Join(testFiles, "more_mp3s", "to_be_moved_directory")
+	movedDir := filepath.Join(testFiles, "library", "to_be_moved_directory")
+	srcTestMp3 := filepath.Join(testFiles, "more_mp3s", "test_file_added.mp3")
+	dstTestMp3 := filepath.Join(testDir, "test_file_added.mp3")
+
+	if err := os.RemoveAll(testDir); err != nil {
+		t.Fatalf("Removing directory needed for tests: %s", err)
+	}
+
+	if err := os.RemoveAll(movedDir); err != nil {
+		t.Fatalf("Removing directory needed for tests: %s", err)
+	}
+
+	lib := getScannedLibrary(t)
+	defer lib.Truncate()
+
+	if err := os.Mkdir(testDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(testDir)
+
+	if err := helpers.Copy(srcTestMp3, dstTestMp3); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Rename(testDir, movedDir); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	checkAddedSong(lib, t)
+
+	if err := os.RemoveAll(movedDir); err != nil {
+		t.Error(err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	results := lib.Search("")
+
+	if len(results) != 3 {
+		t.Errorf("Expected 3 songs but found %d", len(results))
+	}
+}
+
+func TestMovingDirectory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	projRoot, _ := helpers.ProjectRoot()
+	testFiles := filepath.Join(projRoot, "test_files")
+
+	testDir := filepath.Join(testFiles, "more_mp3s", "to_be_moved_directory")
+	movedDir := filepath.Join(testFiles, "library", "to_be_moved_directory")
+	secondPlace := filepath.Join(testFiles, "library", "second_place")
+	srcTestMp3 := filepath.Join(testFiles, "more_mp3s", "test_file_added.mp3")
+	dstTestMp3 := filepath.Join(testFiles, "more_mp3s", "to_be_moved_directory",
+		"test_file_added.mp3")
+
+	_ = os.RemoveAll(testDir)
+	_ = os.RemoveAll(movedDir)
+	_ = os.RemoveAll(secondPlace)
+
+	if err := os.Mkdir(testDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(testDir)
+
+	if err := helpers.Copy(srcTestMp3, dstTestMp3); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Rename(testDir, movedDir); err != nil {
+		t.Fatal(err)
+	} else {
+		defer os.RemoveAll(movedDir)
+	}
+
+	lib := getScannedLibrary(t)
+	defer lib.Truncate()
+
+	checkAddedSong(lib, t)
+
+	if err := os.Rename(movedDir, secondPlace); err != nil {
+		t.Error(err)
+	} else {
+		defer os.RemoveAll(secondPlace)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	checkAddedSong(lib, t)
+
+	found := lib.Search("")
+
+	if len(found) != 4 {
+		t.Errorf("Expected to find 4 tracks but found %d", len(found))
+	}
+
+	found = lib.Search("Added Song")
+
+	if len(found) != 1 {
+		t.Fatalf("Did not find exactly one 'Added Song'. Found %d files", len(found))
+	}
+
+	foundPath := lib.GetFilePath(found[0].ID)
+	expectedPath := filepath.Join(secondPlace, "test_file_added.mp3")
+
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Errorf("File %s was not found: %s", expectedPath, err)
+	}
+
+	if foundPath != expectedPath {
+		t.Errorf("File is in %s according to library. But it is actually in %s",
+			foundPath, expectedPath)
+	}
+
+}
+
+func TestAddingNewFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	lib := getScannedLibrary(t)
+	defer lib.Truncate()
+	projRoot, _ := helpers.ProjectRoot()
+	testFiles := filepath.Join(projRoot, "test_files")
+
+	testMp3 := filepath.Join(testFiles, "more_mp3s", "test_file_added.mp3")
+	newFile := filepath.Join(testFiles, "library", "folder_one", "test_file_added.mp3")
+
+	if err := helpers.Copy(testMp3, newFile); err != nil {
+		t.Fatalf("Copying file to library failed: %s", err)
+	}
+
+	defer os.Remove(newFile)
+
+	time.Sleep(100 * time.Millisecond)
+
+	checkAddedSong(lib, t)
+}
+
+func TestAddingNonRelatedFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	lib := getScannedLibrary(t)
+	defer lib.Truncate()
+	projRoot, _ := helpers.ProjectRoot()
+	testFiles := filepath.Join(projRoot, "test_files")
+	newFile := filepath.Join(testFiles, "library", "not_related")
+
+	testLibFiles := func() {
+		results := lib.Search("")
+		if len(results) != 3 {
+			t.Errorf("Expected 3 files in the library but found %d", len(results))
+		}
+	}
+
+	fh, err := os.Create(newFile)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fh.WriteString("Some contents")
+	fh.Close()
+
+	time.Sleep(100 * time.Millisecond)
+	testLibFiles()
+
+	os.Remove(newFile)
+
+	time.Sleep(100 * time.Millisecond)
+	testLibFiles()
+}

--- a/src/library/local_library.go
+++ b/src/library/local_library.go
@@ -77,9 +77,6 @@ type LocalLibrary struct {
 	// Used to signal when the database writer has stopped
 	dbWriterWG sync.WaitGroup
 
-	// Used in the database writer to shortcircuit a idle heartbeat which no one reads
-	idleTimer *time.Timer
-
 	// Receiving something on this channel means that the database goroutin is in
 	// idle state at the moment
 	databaseWriterIdle chan struct{}
@@ -766,7 +763,6 @@ func NewLocalLibrary(ctx context.Context, databasePath string) (*LocalLibrary, e
 
 	lib.watchLock = &sync.RWMutex{}
 
-	lib.idleTimer = time.NewTimer(1 * time.Millisecond)
 	lib.mediaChan = make(chan string, 100)
 
 	lib.dbWriterWG.Add(1)

--- a/src/library/local_library.go
+++ b/src/library/local_library.go
@@ -362,11 +362,7 @@ func (lib *LocalLibrary) insertMediaIntoDatabase(file MediaFile, filePath string
 	_, err = lib.setTrackID(file.Title(), filePath, int64(file.Track()),
 		artistID, albumID)
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // MediaExistsInLibrary checks if the media file with file system path "filename" has

--- a/src/library/local_library.go
+++ b/src/library/local_library.go
@@ -546,9 +546,9 @@ func (lib *LocalLibrary) setAlbumID(album string, fsPath string) (int64, error) 
 	return lib.lastInsertID()
 }
 
-// GetAlbumFSPath returns all the file paths which contain versions of an album.
+// GetAlbumFSPathByName returns all the file paths which contain versions of an album.
 func (lib *LocalLibrary) GetAlbumFSPathByName(albumName string) ([]string, error) {
-	paths := make([]string, 0)
+	var paths []string
 
 	row, err := lib.db.Query(`
 		SELECT

--- a/src/library/local_library.go
+++ b/src/library/local_library.go
@@ -29,6 +29,12 @@ import (
 // one of them will be saved in the library.
 const UnknownLabel = "Unknown"
 
+// SQLiteMemoryFile can be used as a database path for the sqlite's Open method.
+// When using it, one owuld create a memory database which does not write
+// anything on disk. See https://www.sqlite.org/inmemorydb.html for more info
+// on the subject of in-memory databases.
+const SQLiteMemoryFile = ":memory:"
+
 var (
 	// LibraryFastScan is a flag, populated by the -fast-library-scan argument.
 	//
@@ -737,6 +743,12 @@ func (lib *LocalLibrary) readSchema() (string, error) {
 // Truncate Closes the library and removes its database file leaving no traces at all.
 func (lib *LocalLibrary) Truncate() error {
 	lib.Close()
+
+	// The database is in-memory. There is no file which must be truncated.
+	if lib.database == SQLiteMemoryFile {
+		return nil
+	}
+
 	return os.Remove(lib.database)
 }
 

--- a/src/library/local_library.go
+++ b/src/library/local_library.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/howeyc/fsnotify"
 	taglib "github.com/landr0id/go-taglib"
@@ -275,15 +274,6 @@ func (lib *LocalLibrary) removeDirectory(dirPath string) {
 func (lib *LocalLibrary) databaseWriter(media <-chan string, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	timerDuration := 100 * time.Millisecond
-	idleTimer := time.NewTimer(timerDuration)
-
-	defer func() {
-		if !idleTimer.Stop() {
-			<-idleTimer.C
-		}
-	}()
-
 	for {
 		select {
 		case filename, ok := <-media:
@@ -294,16 +284,9 @@ func (lib *LocalLibrary) databaseWriter(media <-chan string, wg *sync.WaitGroup)
 			if err := lib.AddMedia(filename); err != nil {
 				log.Printf("Error adding `%s` to library: %s\n", filename, err)
 			}
-
-			if !idleTimer.Stop() {
-				<-idleTimer.C
-			}
-
-		case <-idleTimer.C:
 		case <-lib.ctx.Done():
 			return
 		}
-		idleTimer.Reset(timerDuration)
 	}
 }
 

--- a/src/library/local_library.go
+++ b/src/library/local_library.go
@@ -81,7 +81,8 @@ type LocalLibrary struct {
 	ctxCancelFunc context.CancelFunc
 	running       bool
 
-	sync.Mutex
+	isRunningLock sync.Mutex
+	waitScanLock  sync.RWMutex
 }
 
 // Close closes the database connection. It is safe to call it as many times as you want.
@@ -94,8 +95,8 @@ func (lib *LocalLibrary) Close() {
 // related to the library. But leaves the database connection open so that the lib
 // state can be examined via its methods. Useful for testing.
 func (lib *LocalLibrary) stop() {
-	lib.Lock()
-	defer lib.Unlock()
+	lib.isRunningLock.Lock()
+	defer lib.isRunningLock.Unlock()
 
 	if !lib.running {
 		return

--- a/src/library/local_library.go
+++ b/src/library/local_library.go
@@ -32,8 +32,11 @@ const UnknownLabel = "Unknown"
 // SQLiteMemoryFile can be used as a database path for the sqlite's Open method.
 // When using it, one owuld create a memory database which does not write
 // anything on disk. See https://www.sqlite.org/inmemorydb.html for more info
-// on the subject of in-memory databases.
-const SQLiteMemoryFile = ":memory:"
+// on the subject of in-memory databases. We are using a shared cache because
+// this causes all the different connections in the database/sql pool to be
+// connected to the same "memory file". Without this. every new connection
+// would end up creating a new memory database.
+const SQLiteMemoryFile = "file::memory:?cache=shared"
 
 var (
 	// LibraryFastScan is a flag, populated by the -fast-library-scan argument.

--- a/src/library/local_library.go
+++ b/src/library/local_library.go
@@ -77,10 +77,6 @@ type LocalLibrary struct {
 	// Used to signal when the database writer has stopped
 	dbWriterWG sync.WaitGroup
 
-	// Receiving something on this channel means that the database goroutin is in
-	// idle state at the moment
-	databaseWriterIdle chan struct{}
-
 	ctx           context.Context
 	ctxCancelFunc context.CancelFunc
 	running       bool

--- a/src/library/local_library.go
+++ b/src/library/local_library.go
@@ -115,7 +115,7 @@ func (lib *LocalLibrary) AddLibraryPath(path string) {
 	_, err := os.Stat(path)
 
 	if err != nil {
-		log.Println(err)
+		log.Printf("error adding path: %s", err)
 		return
 	}
 
@@ -177,7 +177,7 @@ func (lib *LocalLibrary) GetFilePath(ID int64) string {
 	`)
 
 	if err != nil {
-		log.Println(err)
+		log.Printf("Error getting file path: %s\n", err)
 		return ""
 	}
 
@@ -395,7 +395,7 @@ func (lib *LocalLibrary) MediaExistsInLibrary(filename string) bool {
 	`)
 
 	if err != nil {
-		log.Println(err)
+		log.Printf("could not prepare sql statement: %s", err)
 		return false
 	}
 	defer smt.Close()
@@ -404,7 +404,7 @@ func (lib *LocalLibrary) MediaExistsInLibrary(filename string) bool {
 	err = smt.QueryRow(filename).Scan(&count)
 
 	if err != nil {
-		log.Println(err)
+		log.Printf("error checking whether media exists already: %s", err)
 		return false
 	}
 

--- a/src/library/local_library_scan.go
+++ b/src/library/local_library_scan.go
@@ -12,7 +12,9 @@ import (
 //!TODO: make scan also remove files which have been deleted since the previous scan
 func (lib *LocalLibrary) Scan() {
 	// Make sure there are no other scans working at the moment
-	lib.scanWG.Wait()
+	lib.waitScanLock.RLock()
+	lib.walkWG.Wait()
+	lib.waitScanLock.RUnlock()
 
 	start := time.Now()
 
@@ -23,43 +25,24 @@ func (lib *LocalLibrary) Scan() {
 		time.Sleep(initialWait)
 	}
 
+	lib.waitScanLock.Lock()
 	for _, path := range lib.paths {
 		lib.walkWG.Add(1)
-		go lib.scanPath(path, lib.mediaChan)
+		go lib.scanPath(path)
 	}
+	lib.waitScanLock.Unlock()
 
-	lib.scanWG.Add(1)
-	go func() {
-		lib.walkWG.Wait()
-		log.Printf("Walking took %s", time.Since(start))
-		lib.scanWG.Done()
-	}()
-
-	go func() {
-		lib.WaitScan()
-		log.Printf("Scaning took %s", time.Since(start))
-	}()
-}
-
-// WaitScan blocks the current goroutine until the scan has been finished. This includes
-// all the scanning go routines started by `Scan` along with all additional scanning
-// go routines started during because of events.
-func (lib *LocalLibrary) WaitScan() {
 	lib.waitScanLock.RLock()
-	lib.scanWG.Wait()
+	lib.walkWG.Wait()
 	lib.waitScanLock.RUnlock()
-
-	//!TODO: Cleanup this workaround.
-	// This thing is here because I haven't figured a way to wait for all the running
-	// go routines which make up the scanning process.
-	time.Sleep(100 * time.Millisecond)
+	log.Printf("Scaning took %s", time.Since(start))
 }
 
 // This is the goroutine which actually scans a library path.
 // For now it ignores everything but the list of supported files. It is so
 // because jplayer cannot play anything else. Sends every suitable
 // file into the media channel
-func (lib *LocalLibrary) scanPath(scannedPath string, media chan<- string) {
+func (lib *LocalLibrary) scanPath(scannedPath string) {
 	start := time.Now()
 
 	defer func() {
@@ -80,7 +63,7 @@ func (lib *LocalLibrary) scanPath(scannedPath string, media chan<- string) {
 		}
 
 		if lib.isSupportedFormat(path) {
-			media <- path
+			lib.writeInDb(path)
 		}
 
 		lib.watchLock.RLock()

--- a/src/library/local_library_scan.go
+++ b/src/library/local_library_scan.go
@@ -73,7 +73,7 @@ func (lib *LocalLibrary) scanPath(scannedPath string, media chan<- string) {
 	walkFunc := func(path string, info os.FileInfo, err error) error {
 
 		if err != nil {
-			log.Println(err)
+			log.Printf("error while scanning %s: %s", path, err)
 			return nil
 		}
 
@@ -105,6 +105,6 @@ func (lib *LocalLibrary) scanPath(scannedPath string, media chan<- string) {
 	err := filepath.Walk(scannedPath, walkFunc)
 
 	if err != nil {
-		log.Println(err)
+		log.Printf("error while walking %s: %s", scannedPath, err)
 	}
 }

--- a/src/library/local_library_scan.go
+++ b/src/library/local_library_scan.go
@@ -45,7 +45,9 @@ func (lib *LocalLibrary) Scan() {
 // all the scanning go routines started by `Scan` along with all additional scanning
 // go routines started during because of events.
 func (lib *LocalLibrary) WaitScan() {
+	lib.waitScanLock.RLock()
 	lib.scanWG.Wait()
+	lib.waitScanLock.RUnlock()
 
 	//!TODO: Cleanup this workaround.
 	// This thing is here because I haven't figured a way to wait for all the running

--- a/src/library/local_library_watch.go
+++ b/src/library/local_library_watch.go
@@ -90,11 +90,11 @@ func (lib *LocalLibrary) handleWatchEvent(event *fsnotify.FileEvent) {
 	if event.IsCreate() && st.IsDir() {
 		lib.watch.Watch(event.Name)
 
-		//!TODO: the next line is actually a race condition. Calling `Add` while
-		// a different goroutine/thread is waiting on the wait groupd causes it.
+		lib.waitScanLock.Lock()
 		lib.walkWG.Add(1)
-		go lib.scanPath(event.Name, lib.mediaChan)
+		lib.waitScanLock.Unlock()
 
+		go lib.scanPath(event.Name, lib.mediaChan)
 		return
 	}
 

--- a/src/library/local_library_watch.go
+++ b/src/library/local_library_watch.go
@@ -90,9 +90,8 @@ func (lib *LocalLibrary) handleWatchEvent(event *fsnotify.FileEvent) {
 	if event.IsCreate() && st.IsDir() {
 		lib.watch.Watch(event.Name)
 
-		//!TODO: the next two lines are actually a race condition. An alternative way
-		// for achieving this must be found. It seems that calling `Add` on the wait
-		// group is the problem. One can detect it with `go test -race`.
+		//!TODO: the next line is actually a race condition. Calling `Add` while
+		// a different goroutine/thread is waiting on the wait groupd causes it.
 		lib.walkWG.Add(1)
 		go lib.scanPath(event.Name, lib.mediaChan)
 

--- a/src/main.go
+++ b/src/main.go
@@ -6,6 +6,7 @@
 package src
 
 import (
+	"context"
 	"flag"
 	"log"
 	"os"
@@ -56,7 +57,7 @@ func Main() {
 }
 
 // SetupPidFileAndSignals creates a pidfile and starts a signal receiver goroutine
-func SetupPidFileAndSignals(pidFile string) {
+func SetupPidFileAndSignals(pidFile string, stopFunc context.CancelFunc) {
 	helpers.SetUpPidFile(pidFile)
 
 	signalChannel := make(chan os.Signal, 2)
@@ -66,8 +67,8 @@ func SetupPidFileAndSignals(pidFile string) {
 	go func() {
 		for range signalChannel {
 			log.Println("Stop signal received. Removing pidfile and stopping.")
+			stopFunc()
 			helpers.RemovePidFile(pidFile)
-			os.Exit(0)
 		}
 	}()
 }
@@ -75,9 +76,11 @@ func SetupPidFileAndSignals(pidFile string) {
 // Returns a new Library object using the application config.
 // For the moment this is a LocalLibrary which will place its sqlite db file
 // in the UserPath directory
-func getLibrary(userPath string, cfg config.Config) (library.Library, error) {
+func getLibrary(ctx context.Context, userPath string,
+	cfg config.Config) (library.Library, error) {
+
 	dbPath := helpers.AbsolutePath(cfg.SqliteDatabase, userPath)
-	lib, err := library.NewLocalLibrary(dbPath)
+	lib, err := library.NewLocalLibrary(ctx, dbPath)
 
 	if err != nil {
 		return nil, err
@@ -118,11 +121,14 @@ func ParseConfigAndStartWebserver(projRoot string) error {
 		}
 	}
 
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
 	pidFile := helpers.AbsolutePath(PidFile, userPath)
-	SetupPidFileAndSignals(pidFile)
+	SetupPidFileAndSignals(pidFile, cancelCtx)
 	defer helpers.RemovePidFile(pidFile)
 
-	lib, err := getLibrary(userPath, cfg)
+	lib, err := getLibrary(ctx, userPath, cfg)
 	if err != nil {
 		return err
 	}
@@ -130,7 +136,7 @@ func ParseConfigAndStartWebserver(projRoot string) error {
 
 	cfg.HTTPRoot = helpers.AbsolutePath(cfg.HTTPRoot, projRoot)
 
-	srv := webserver.NewServer(cfg, lib)
+	srv := webserver.NewServer(ctx, cfg, lib)
 	srv.Serve()
 	srv.Wait()
 	return nil

--- a/src/main.go
+++ b/src/main.go
@@ -132,7 +132,7 @@ func ParseConfigAndStartWebserver(projRoot string) error {
 	if err != nil {
 		return err
 	}
-	lib.Scan()
+	go lib.Scan()
 
 	cfg.HTTPRoot = helpers.AbsolutePath(cfg.HTTPRoot, projRoot)
 

--- a/src/webserver/handler_album.go
+++ b/src/webserver/handler_album.go
@@ -61,14 +61,14 @@ func (fh AlbumHandler) find(writer http.ResponseWriter, req *http.Request) error
 // every file is its filepath.Base.
 func (fh AlbumHandler) writeZipContents(writer io.Writer, files []string) error {
 
-	var err error
 	zipWriter := zip.NewWriter(writer)
 
 	for _, file := range files {
 		fh, err := os.Open(file)
 
 		if err != nil {
-			goto problem_writing
+			_ = zipWriter.Close()
+			return err
 		}
 
 		defer fh.Close()
@@ -76,27 +76,24 @@ func (fh AlbumHandler) writeZipContents(writer io.Writer, files []string) error 
 		contents, err := ioutil.ReadAll(fh)
 
 		if err != nil {
-			goto problem_writing
+			_ = zipWriter.Close()
+			return err
 		}
 
 		zfh, err := zipWriter.Create(filepath.Base(file))
 		if err != nil {
-			goto problem_writing
+			_ = zipWriter.Close()
+			return err
 		}
 
 		_, err = zfh.Write(contents)
 		if err != nil {
-			goto problem_writing
+			_ = zipWriter.Close()
+			return err
 		}
 	}
 
-	err = zipWriter.Close()
-
-	return err
-
-problem_writing:
-	_ = zipWriter.Close()
-	return err
+	return zipWriter.Close()
 }
 
 // NewAlbumHandler returns a new Album handler. It needs a library to search in

--- a/src/webserver/handler_album.go
+++ b/src/webserver/handler_album.go
@@ -92,11 +92,7 @@ func (fh AlbumHandler) writeZipContents(writer io.Writer, files []string) error 
 
 	err = zipWriter.Close()
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 
 problem_writing:
 	_ = zipWriter.Close()

--- a/src/webserver/handler_basicauth.go
+++ b/src/webserver/handler_basicauth.go
@@ -19,7 +19,7 @@ type BasicAuthHandler struct {
 func (hl BasicAuthHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	auth, err := req.Header["Authorization"]
 
-	if err == false || len(auth) < 1 || hl.authenticate(auth[0]) == false {
+	if !err || len(auth) < 1 || !hl.authenticate(auth[0]) {
 		InternalErrorOnErrorHandler(writer, req, hl.challengeAuthentication)
 		return
 	}
@@ -41,11 +41,7 @@ func (hl BasicAuthHandler) challengeAuthentication(writer http.ResponseWriter,
 
 	err = tmpl.Execute(writer, nil)
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // Compares the authentication header with the stored user and passwords

--- a/src/webserver/webserver_test.go
+++ b/src/webserver/webserver_test.go
@@ -217,7 +217,7 @@ func TestSSL(t *testing.T) {
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
+	} // #nosec
 	client := &http.Client{Transport: tr}
 	_, err = client.Get(fmt.Sprintf("https://127.0.0.1:%d", TestPort))
 

--- a/src/webserver/webserver_test.go
+++ b/src/webserver/webserver_test.go
@@ -36,7 +36,7 @@ func testErrorAfter(seconds time.Duration, message string) chan int {
 
 	go func() {
 		select {
-		case _ = <-ch:
+		case <-ch:
 			close(ch)
 			return
 		case <-time.After(seconds * time.Second):

--- a/src/webserver/webserver_test.go
+++ b/src/webserver/webserver_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -61,7 +62,7 @@ func setUpServer() *Server {
 	wsCfg.HTTPRoot = filepath.Join(projRoot, "test_files", TestRoot)
 	wsCfg.Gzip = true
 
-	return NewServer(wsCfg, nil)
+	return NewServer(context.Background(), wsCfg, nil)
 }
 
 func tearDownServer(srv *Server) {
@@ -96,7 +97,7 @@ func getProjectRoot() (string, error) {
 func getLibraryServer(t *testing.T) (*Server, library.Library) {
 	projRoot, _ := getProjectRoot()
 
-	lib, err := library.NewLocalLibrary("/tmp/test-web-file-get.db")
+	lib, err := library.NewLocalLibrary(context.TODO(), library.SQLiteMemoryFile)
 
 	if err != nil {
 		t.Fatal(err)
@@ -119,7 +120,7 @@ func getLibraryServer(t *testing.T) (*Server, library.Library) {
 	wsCfg.Listen = fmt.Sprintf("127.0.0.1:%d", TestPort)
 	wsCfg.HTTPRoot = filepath.Join(projRoot, "test_files", TestRoot)
 
-	srv := NewServer(wsCfg, lib)
+	srv := NewServer(context.Background(), wsCfg, lib)
 	srv.Serve()
 
 	return srv, lib
@@ -209,7 +210,7 @@ func TestSSL(t *testing.T) {
 		Key: filepath.Join(certDir, "key.pem"),
 	}
 
-	srv := NewServer(wsCfg, nil)
+	srv := NewServer(context.Background(), wsCfg, nil)
 	srv.Serve()
 
 	defer tearDownServer(srv)
@@ -243,7 +244,7 @@ func TestUserAuthentication(t *testing.T) {
 		Password: "testpass",
 	}
 
-	srv := NewServer(wsCfg, nil)
+	srv := NewServer(context.Background(), wsCfg, nil)
 	srv.Serve()
 	defer tearDownServer(srv)
 
@@ -290,7 +291,7 @@ func TestUserAuthentication(t *testing.T) {
 func TestSearchUrl(t *testing.T) {
 	projRoot, _ := getProjectRoot()
 
-	lib, _ := library.NewLocalLibrary("/tmp/test-web-search.db")
+	lib, _ := library.NewLocalLibrary(context.TODO(), library.SQLiteMemoryFile)
 	err := lib.Initialize()
 
 	if err != nil {
@@ -310,7 +311,7 @@ func TestSearchUrl(t *testing.T) {
 	wsCfg.Listen = fmt.Sprintf("127.0.0.1:%d", TestPort)
 	wsCfg.HTTPRoot = filepath.Join(projRoot, "test_files", TestRoot)
 
-	srv := NewServer(wsCfg, lib)
+	srv := NewServer(context.Background(), wsCfg, lib)
 	srv.Serve()
 	defer tearDownServer(srv)
 
@@ -494,7 +495,7 @@ func TestGzipEncoding(t *testing.T) {
 	wsCfg.HTTPRoot = filepath.Join(projRoot, "test_files", TestRoot)
 	wsCfg.Gzip = true
 
-	srv := NewServer(wsCfg, nil)
+	srv := NewServer(context.Background(), wsCfg, nil)
 	srv.Serve()
 
 	tests := [][2]string{
@@ -508,7 +509,7 @@ func TestGzipEncoding(t *testing.T) {
 	tearDownServer(srv)
 
 	wsCfg.Gzip = false
-	srv = NewServer(wsCfg, nil)
+	srv = NewServer(context.Background(), wsCfg, nil)
 	srv.Serve()
 	defer tearDownServer(srv)
 

--- a/src/webserver/webserver_test.go
+++ b/src/webserver/webserver_test.go
@@ -562,8 +562,13 @@ func TestAlbumHandlerOverHttp(t *testing.T) {
 	defer lib.Truncate()
 	defer tearDownServer(srv)
 
-	artistID, _ := lib.(*library.LocalLibrary).GetArtistID("Artist Testoff")
-	albumID, _ := lib.(*library.LocalLibrary).GetAlbumID("Album Of Tests", artistID)
+	albumPaths, err := lib.(*library.LocalLibrary).GetAlbumFSPathByName("Album Of Tests")
+
+	if err != nil {
+		t.Fatalf("Cannot get album path: %s", err)
+	}
+
+	albumID, _ := lib.(*library.LocalLibrary).GetAlbumID("Album Of Tests", albumPaths[0])
 
 	albumURL := fmt.Sprintf("http://127.0.0.1:%d/album/%d", TestPort, albumID)
 

--- a/src/webserver/webserver_test.go
+++ b/src/webserver/webserver_test.go
@@ -110,10 +110,9 @@ func getLibraryServer(t *testing.T) (*Server, library.Library) {
 	}
 
 	lib.AddLibraryPath(filepath.Join(projRoot, "test_files", "library"))
-	lib.Scan()
 
 	ch := testErrorAfter(5, "Library in TestGetFileUrl did not finish scaning on time")
-	lib.WaitScan()
+	lib.Scan()
 	ch <- 42
 
 	var wsCfg config.Config
@@ -301,10 +300,9 @@ func TestSearchUrl(t *testing.T) {
 	defer lib.Truncate()
 
 	lib.AddLibraryPath(filepath.Join(projRoot, "test_files", "library"))
-	lib.Scan()
 
 	ch := testErrorAfter(5, "Library in TestSearchUrl did not finish scaning on time")
-	lib.WaitScan()
+	lib.Scan()
 	ch <- 42
 
 	var wsCfg config.Config


### PR DESCRIPTION
An album is now uniquely identified by its name and a filesystem location. This is changed from name and artist ID which proved unsuitable for albums which include many artists.